### PR TITLE
Uso de Mailtrap y BugFix

### DIFF
--- a/YateMate.Aplicacion/Entidades/AuthMessageSenderOptions.cs
+++ b/YateMate.Aplicacion/Entidades/AuthMessageSenderOptions.cs
@@ -3,6 +3,4 @@ namespace YateMate.Aplicacion.Entidades;
 public class AuthMessageSenderOptions
 {
     public string? EmailAuthKey { get; set; } //en el tutorial original usaba esto para la api, aca lo voy a usar para guardar la clave no segura
-
-    public string? ActualEmail { get; set; } // aca guardo el mail, seteado por una e.v para no subir los datos a git
 }

--- a/YateMate.Aplicacion/Entidades/EmailSender.cs
+++ b/YateMate.Aplicacion/Entidades/EmailSender.cs
@@ -29,11 +29,11 @@ public class EmailSender(IOptions<AuthMessageSenderOptions> optionsAccessor,
     
     public async Task SendEmailAsync(string toEmail, string subject, string message)
     {
-        if (string.IsNullOrEmpty(Options.EmailAuthKey) || string.IsNullOrEmpty(Options.ActualEmail))
+        if (string.IsNullOrEmpty(Options.EmailAuthKey))
         {
             
-            Console.WriteLine($"contrasenia: {Options.EmailAuthKey} mail: {Options.ActualEmail} options to string {Options.ToString()}");
-            throw new Exception("Contraseña del mail o el mail en si no estan seteados. Agregaste los secretos?");
+            Console.WriteLine($"Api Mailtrap: {Options.EmailAuthKey} ");
+            throw new Exception("La apiKey es null o no esta seteada. Agregaste el secreto?");
             
         }
 
@@ -43,14 +43,18 @@ public class EmailSender(IOptions<AuthMessageSenderOptions> optionsAccessor,
     public async Task Execute(string apiKey, string subject, string message, 
         string toEmail)
     {
-        //usamos el servidor smtp que te da gmail, necesitas tener una cuenta con 2fa y habilitar application passwords
-         var client = new SmtpClient("smtp.gmail.com", 587);
-         string? pass = Options.EmailAuthKey;
-         string? emailFrom = Options.ActualEmail;
-         client.Credentials = new NetworkCredential(emailFrom, pass);
+        if (message.Contains("amp;"))
+        {
+            message = message.Replace("&amp;", "&");
+        }
+         var client = new SmtpClient("sandbox.smtp.mailtrap.io", 2525)
+         {
+             Credentials = new NetworkCredential("b7680a9e8a9a3a", apiKey),
+             EnableSsl = true
+         };
          client.EnableSsl = true;
-         await client.SendMailAsync(emailFrom, toEmail, subject, message);
+         client.Send("YateMate@YateMate.com", toEmail, subject, message);
          
-         _logger.LogInformation("Email to {EmailAddress} sent!", toEmail);
+         _logger.LogInformation($"Email to {toEmail} sent!, with subject {subject} and message {message}");
      }
 }

--- a/YateMate/Components/Account/Pages/Manage/ChangePassword.razor
+++ b/YateMate/Components/Account/Pages/Manage/ChangePassword.razor
@@ -33,7 +33,6 @@
 
 <div class="row">
     <div class="col-md-6">
-        
         <EditForm Model="Input" FormName="change-password" OnValidSubmit="OnValidSubmitAsync" method="post">
             <InputText hidden="true" @bind-Value="Input.a"/>
             <button type="submit" class="w-100 btn btn-lg btn-primary">Solicitar Cambio</button>

--- a/YateMate/Components/Account/Pages/ResetPassword.razor
+++ b/YateMate/Components/Account/Pages/ResetPassword.razor
@@ -3,12 +3,14 @@
 
 @using System.ComponentModel.DataAnnotations
 @using System.Text
+@using System.Web
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
 @using YateMate.Aplicacion.Entidades;
 
 @inject IdentityRedirectManager RedirectManager
 @inject UserManager<ApplicationUser> UserManager
+@inject NavigationManager MyNavigationManager
 
 <PageTitle>Reset password</PageTitle>
 
@@ -37,6 +39,7 @@
         </EditForm>
     </div>
 </div>
+
 @code {
     
     private IEnumerable<IdentityError>? _identityErrors;
@@ -44,9 +47,9 @@
     [SupplyParameterFromForm] private InputModel Input { get; set; } = new();
 
     [SupplyParameterFromQuery] private string? Code { get; set; }
-    
-    [SupplyParameterFromQuery] private string? email { get; set; } 
 
+    [SupplyParameterFromQuery] private string? email { get; set; }
+    
     private string? Message => _identityErrors is null ? null : $"Error: {string.Join(", ", _identityErrors.Select(error => error.Description))}";
 
     protected override void OnInitialized()
@@ -57,9 +60,20 @@
         }
 
         Input.Code = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(Code));
-        Input.InpEmail = email; //hago esto porque en la hu dijimos que solo ponia la contraseña no el mail
-        Console.WriteLine($"el email del usuario actual el cual conseguimos por un parametro en la url es {email}");
         
+        if (email is null) //si email es null es porque el villero de mailtrap me puso el &amp;
+        {
+            string decodedUrl = MyNavigationManager.Uri.Replace("&amp;", "&");;
+            Console.WriteLine($"la url actual sin el amp es {decodedUrl}");
+            var parameters = HttpUtility.ParseQueryString(decodedUrl);
+
+            // Get the value of the "email" parameter
+            email = parameters["email"];
+        }
+        Input.InpEmail = email; //hago esto porque en la hu dijimos que solo ponia la contraseña no el mail
+        Console.WriteLine($"tenemos un amp en la url? {MyNavigationManager.Uri.Contains("amp;")}");
+        Console.WriteLine($"el parametro mail es {email}");
+
     }
 
     private async Task OnValidSubmitAsync()

--- a/YateMate/Components/Layout/NavMenu.razor
+++ b/YateMate/Components/Layout/NavMenu.razor
@@ -26,12 +26,22 @@
         @* </div> *@
 
         
-            
-        <AuthorizeView Roles="Cliente, Empleado">
+            @* <AuthorizeView Roles="Cliente, Empleado"> *@
+        <AuthorizeView Roles="Cliente">
             <Authorized>
                 <div class="nav-item px-3">
                     <NavLink class="nav-link" href="Account/Manage">
                         <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Mi perfil
+                    </NavLink>
+                </div>
+            </Authorized>
+        </AuthorizeView>
+        
+        <AuthorizeView Roles="Empleado">
+            <Authorized>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="empleado">
+                        <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Solo empleados
                     </NavLink>
                 </div>
             </Authorized>

--- a/YateMate/Components/Pages/Admin.razor
+++ b/YateMate/Components/Pages/Admin.razor
@@ -1,0 +1,8 @@
+@page "/admin"
+
+<h3>Admin</h3>
+
+<p> solo el admin puede ver esto</p>
+@code {
+    
+}

--- a/YateMate/Components/Pages/Empleado.razor
+++ b/YateMate/Components/Pages/Empleado.razor
@@ -1,0 +1,8 @@
+@page "/empleado"
+
+<h3>Empleado</h3>
+
+<p> Solo empleados pueden ver esto </p>
+@code {
+    
+}


### PR DESCRIPTION
Pasamos de enviar mail por gmail a usar Mailtrap (actualizen secreto de EmailAuthKey y no usen más ActualEmail) esto produjo un bug en el que a la url se le agregaba un &amp; en vez de & que rompía todo, se agregó un chequeo en EmailSender.cs y en ResetPassword.razor